### PR TITLE
Add manual timestamp and label controls

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,9 +1,13 @@
 from app.extensions import db
 
+from datetime import datetime
+
+
 class Image(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     path = db.Column(db.String(200))
     label = db.Column(db.String(10))  # full or empty
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 
     features = db.relationship("Feature", backref="image", uselist=False)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, render_template, request, redirect, url_for, current_app
 from werkzeug.utils import secure_filename
 import os
+from datetime import datetime
+from PIL import Image as PILImage, ExifTags
 from app.feature_extraction import extract_features
 from app.rules import classify_image
 from app.db.models import Image, Feature
@@ -8,28 +10,51 @@ from app.extensions import db
 
 main = Blueprint('main', __name__)
 
+
+def _read_exif_timestamp(path):
+    """Extract DateTimeOriginal from image EXIF data."""
+    try:
+        img = PILImage.open(path)
+        exif = img._getexif() or {}
+        for tag_id, value in exif.items():
+            tag = ExifTags.TAGS.get(tag_id)
+            if tag == 'DateTimeOriginal':
+                return datetime.strptime(value, "%Y:%m:%d %H:%M:%S")
+    except Exception:
+        pass
+    return datetime.utcnow()
+
 @main.route("/", methods=["GET", "POST"])
 def upload():
     if request.method == "POST":
         file = request.files["image"]
+        timestamp_str = request.form.get("timestamp")
+        label_auto = request.form.get("label_auto", "true") == "true"
+        manual_label = request.form.get("label")
+
         filename = secure_filename(file.filename)
         path = os.path.join(current_app.config["UPLOAD_FOLDER"], filename)
         file.save(path)
 
+        # Determine timestamp
+        if timestamp_str:
+            img_timestamp = datetime.fromisoformat(timestamp_str)
+        else:
+            img_timestamp = _read_exif_timestamp(path)
+
+        # Extract features and classify
+        features = extract_features(path)
+        predicted_label = classify_image(features)
+        final_label = predicted_label if label_auto else manual_label
+
         # Save image record
-        img = Image(path=path)
+        img = Image(path=path, label=final_label, timestamp=img_timestamp)
         db.session.add(img)
         db.session.commit()
 
-        # Extract features
-        features = extract_features(path)
+        # Store features
         feat = Feature(image_id=img.id, **features)
         db.session.add(feat)
-        db.session.commit()
-
-        # Classify
-        label = classify_image(features)
-        img.label = label
         db.session.commit()
 
         return redirect(url_for(".upload"))

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,9 +2,22 @@
 {% block title %}Upload{% endblock %}
 {% block content %}
 
-<form method="POST" enctype="multipart/form-data">
+<form method="POST" enctype="multipart/form-data" id="uploadForm">
     <div class="mb-3">
-        <input type="file" name="image" class="form-control" required>
+        <input type="file" name="image" id="imageInput" class="form-control" required>
+    </div>
+    <div class="mb-3">
+        <label for="timestampInput" class="form-label">Timestamp</label>
+        <input type="datetime-local" name="timestamp" id="timestampInput" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label for="labelSelect" class="form-label">Status</label>
+        <select name="label" id="labelSelect" class="form-select">
+            <option value="full">Full</option>
+            <option value="empty">Empty</option>
+        </select>
+        <input type="hidden" name="label_auto" id="labelAuto" value="true">
+        <button type="button" id="resetAutoBtn" class="btn btn-sm btn-secondary mt-2">Reset to Auto</button>
     </div>
     <button type="submit" class="btn btn-primary">Upload</button>
 </form>
@@ -21,5 +34,64 @@
     </div>
     {% endfor %}
 </div>
+
+<script src="https://cdn.jsdelivr.net/npm/exif-js"></script>
+<script>
+let predictedLabel = null;
+const imageInput = document.getElementById('imageInput');
+const timestampInput = document.getElementById('timestampInput');
+const labelSelect = document.getElementById('labelSelect');
+const labelAuto = document.getElementById('labelAuto');
+const resetBtn = document.getElementById('resetAutoBtn');
+
+imageInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    EXIF.getData(file, function() {
+        const exifDate = EXIF.getTag(this, 'DateTimeOriginal');
+        if (exifDate) {
+            const [date, time] = exifDate.split(' ');
+            const formatted = date.replace(/:/g, '-') + 'T' + time.slice(0,5);
+            timestampInput.value = formatted;
+        } else {
+            timestampInput.value = new Date().toISOString().slice(0,16);
+        }
+    });
+
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+        const img = new Image();
+        img.onload = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = 1;
+            canvas.height = 1;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(img, 0, 0, 1, 1);
+            const data = ctx.getImageData(0,0,1,1).data;
+            const avgR = data[0];
+            const label = (avgR < 100 && file.size > 100000) ? 'full' : 'empty';
+            predictedLabel = label;
+            labelSelect.value = label;
+            labelAuto.value = 'true';
+        };
+        img.src = ev.target.result;
+    };
+    reader.readAsDataURL(file);
+});
+
+labelSelect.addEventListener('change', () => {
+    if (predictedLabel && labelSelect.value !== predictedLabel) {
+        labelAuto.value = 'false';
+    }
+});
+
+resetBtn.addEventListener('click', () => {
+    if (predictedLabel) {
+        labelSelect.value = predictedLabel;
+        labelAuto.value = 'true';
+    }
+});
+</script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow images to store a timestamp
- permit upload form to edit timestamp
- preload timestamp from EXIF via JS
- auto–detect bin status in browser and allow manual override

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d900d3fb483298180d03e2be84c72